### PR TITLE
Unit test for edgeDetection processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ cmake_install.cmake
 
 CTestTestfile.cmake
 src/camera_autogen/
+src/edgeDetection_autogen/
 test/CTestTestfile.cmake
 test/main
 Testing/

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,10 @@ add_executable(OpenFlexure main.cpp camera.cpp gui.cpp processingTemplate.cpp ed
 target_link_libraries(OpenFlexure ${OpenCV_LIBS} Qt5::Widgets Threads::Threads)
 
 
-#create library for testing
+#create libraries for testing
+
 add_library(camera camera.cpp camera.h)
 target_link_libraries(camera ${OpenCV_LIBS} Threads::Threads)
+
+add_library(edgeDetection edgeDetection.cpp edgeDetection.h)
+target_link_libraries(edgeDetection ${OpenCV_LIBS} Threads::Threads)

--- a/src/edgeDetection.cpp
+++ b/src/edgeDetection.cpp
@@ -37,6 +37,7 @@ void edgeDetection::enhanceEdge(frame inputFrame) {
     // Convert output cv::Mat to frame
     frame outputFrame;
     outputFrame.image = output_mat.clone();
+    outputFrame.note = "Frame processed through edge detection";  //processing note
 
     // Output the frame through the callback onto the next instance in the dataflow
     frameCb->newFrame(outputFrame);

--- a/src/edgeDetection.cpp
+++ b/src/edgeDetection.cpp
@@ -37,7 +37,7 @@ void edgeDetection::enhanceEdge(frame inputFrame) {
     // Convert output cv::Mat to frame
     frame outputFrame;
     outputFrame.image = output_mat.clone();
-    outputFrame.note = "Frame processed through edge detection";  //processing note
+    outputFrame.note = "Frame processed through edge detection";  //processing note, if updated must update test
 
     // Output the frame through the callback onto the next instance in the dataflow
     frameCb->newFrame(outputFrame);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,4 +11,4 @@ include_directories(../src)
 enable_testing()
 
 add_executable(main main.cpp)
-target_link_libraries(main ${OpenCV_LIBS} gtest gtest_main camera)
+target_link_libraries(main ${OpenCV_LIBS} gtest gtest_main camera edgeDetection)

--- a/test/gtest_edgedetect.h
+++ b/test/gtest_edgedetect.h
@@ -1,0 +1,31 @@
+#include <gtest/gtest.h>
+#include "gtest_endtest.h"
+#include "edgeDetection.h"
+
+#include <opencv2/core.hpp>
+#include <opencv2/videoio.hpp>
+#include <iostream>
+
+
+TEST(edgeDetectTest, checkOutputNote){
+    
+    EndTester endtest;
+    edgeDetection edge;
+
+    imageProcessor::frame expected; //expected output frame
+    // cv::Mat cap;      
+    // expected.image = cap;
+    expected.note = "Frame processed through edge detection"; //note from running through edge detection
+    // expected.note = "This is a dummy note"; //debug, using this note will cause a fail
+    
+    imageProcessor::frame f;
+    cv::Mat capture;        // using a capture that is empty for now
+    capture.create(5, 5, 1);
+    f.image = capture;
+    f.note = "";
+
+    edge.registerCallback(&endtest);
+    edge.newFrame(f);
+
+    EXPECT_EQ(endtest.currentFrame.note, expected.note);
+}

--- a/test/gtest_edgedetect.h
+++ b/test/gtest_edgedetect.h
@@ -15,14 +15,15 @@ TEST(edgeDetectTest, checkOutputNote){
     imageProcessor::frame expected; //expected output frame
     // cv::Mat cap;      
     // expected.image = cap;
-    expected.note = "Frame processed through edge detection"; //note from running through edge detection
+    expected.note = "Frame processed through edge detection"; //note from running through edge detection, must match edgeDetection.cpp
     // expected.note = "This is a dummy note"; //debug, using this note will cause a fail
     
     imageProcessor::frame f;
-    cv::Mat capture;        // using a capture that is empty for now
-    capture.create(5, 5, 1);
+    cv::Mat capture;  
+    capture.create(5, 5, 1);    //random matrix to process, output not used in test
     f.image = capture;
     f.note = "";
+    // POSSIBLE IMPROVEMENT: expand frame struct to include dedicated testnote aside from note?
 
     edge.registerCallback(&endtest);
     edge.newFrame(f);

--- a/test/gtest_endtest.h
+++ b/test/gtest_endtest.h
@@ -1,0 +1,23 @@
+#ifndef GTEST_ENDTEST
+#define GTEST_ENDTEST
+
+
+#include <opencv2/core.hpp>
+#include <opencv2/videoio.hpp>
+
+#include <iostream>
+#include <stdlib.h>
+#include <thread>
+
+#include "imageProcessor.h"
+
+class EndTester : public imageProcessor{
+    public:
+        void newFrame(frame newFrame){
+            currentFrame = newFrame;
+        }
+        frame currentFrame;
+};
+
+
+#endif //GTEST_ENDTEST

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include "gtest_camera.h"
+#include "gtest_edgedetect.h"
 
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Expands unit test suite to include initial test for edgeDetection class based on the frame note to verify a frame has successfully been passed through. Updated edgeDetection.cpp to add a note to output frame for this purpose.

Wonder if it would be worthwhile expanding the frame struct to include a dedicated "testnote" for this sort of test, or using the existing note is sufficient?

Also includes a test tool to get the output frames through the callback system to be able to run tests on the output.
