### PR TITLE
Gallery capture feature

### DIFF
--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -103,18 +103,22 @@ void Gui::initialiseGallery(){
     //to find if files with current name already exist
     //to avoid overwriting the files
     if ((dir = opendir(pathname.c_str())) != NULL) {
-        /* print all the files and directories within directory */
+        
+        //iterate over all entries in the gallery directory
         while ((ent = readdir(dir)) != NULL) {
 
-            //build filename to check if there
-            //build output name string
-            //captureFname = pathname + imgName + std::to_string(captureImgCounter) +".jpg";
-            
             //get name of file
             existingCaptureFname = ent->d_name;
+
+            //if file matches the set filename template
             if (existingCaptureFname.substr(0, imgName.length()) == imgName){
-                //get number of file
-                index = std::stoi(existingCaptureFname.substr(imgName.length(), 1));
+   
+                //get number of digits of file index in filename
+                indexLen = existingCaptureFname.length() - imgName.length() - 4; //4 for .jpg chars
+
+                //get file index
+                index = std::stoi(existingCaptureFname.substr(imgName.length(), indexLen));
+                 
                 //if index is higher than last highest found
                 if (index > lastHighestIndex){
                     captureImgCounter = index + 1;
@@ -125,7 +129,7 @@ void Gui::initialiseGallery(){
     closedir(dir);
     
     //debug
-    std::cout << std::to_string(captureImgCounter) + " ALREADY FOUND" << std::endl;
+    //std::cout << std::to_string(captureImgCounter) + " ALREADY FOUND" << std::endl;
     }  
 
 }

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1,6 +1,13 @@
 #include "gui.h"
 
+//TODO cleanup
+//check if dir already exists
+//get highest number already there so no overwrite
+//error checking if no pathname 
 
+//FUTURE todo:
+//configureable dir name and filename 
+//metadata saved? inside jpg or alongside companion file to be viewed in OpenFlexure gallery?
 
 Gui::Gui(QMainWindow* win, Ui_GUI* ui_win) {
     widget = win;
@@ -12,20 +19,27 @@ Gui::Gui(QMainWindow* win, Ui_GUI* ui_win) {
     //push button (to be renamed @Jake) connects to gallery capture
     QObject::connect(ui->pushButton, &QPushButton::released, this, &Gui::captureNextFrame);
 
-
+    //---- find or create gallery directory----
     pathname = getenv("HOME");
     pathname += + "/OpenFlexureGallery/"; 
-    if (mkdir(pathname.c_str(), S_IRWXU) == -1){
-    //if (mkdir("testMKDIR", S_IRWXU) == -1){
-        std::cerr << "Error :  " << std::strerror(errno) << std::endl;
-        std::cout << "Gallery directory not found/created";
-        //disable button if failed
+    
+    //if it doesn't exist
+    if ((dir = opendir(pathname.c_str())) == NULL){
+        //try to make the directory
+        if (mkdir(pathname.c_str(), S_IRWXU) == -1){
+            //if failed:
+            std::cerr << "Error :  " << std::strerror(errno) << std::endl;
+            std::cout << "Gallery directory not found/created";
+            //ADD. disable button if failed
+            pathname = ""; 
+        }
+        else{//if gallery succesfully made
+            std::cout << "Gallery directory created at " + pathname << std::endl;
+        }
+    }else{//if gallery already exists
+        std::cout << "Gallery directory found at " + pathname << std::endl;
     }
-    else{
-        std::cout << "Gallery directory found at " + pathname;
-    }
-    //std::string home_dir = getenv("HOME");
-    //std::cout << home_dir <<std::endl;
+
 }
 void Gui::newFrame(frame newFrame) {
 
@@ -69,14 +83,14 @@ void Gui::captureFrame(frame capFrame){
         //add ability to set custom string before number
 
         //build output name string
-        captureFname = pathname + "testCapture_";
-        captureFname += std::to_string(captureImgCounter);
-        captureFname += ".jpg";
+        captureFname = pathname + imgName + std::to_string(captureImgCounter) +".jpg";;
+        // captureFname += std::to_string(captureImgCounter);
+        // captureFname += ".jpg";
 
 
         //save image
         img = capFrame.image;
-        cv::imwrite(captureFname, img); //watch out for bgr vs rgb CHECK THIS
+        cv::imwrite(captureFname, img); 
         doCapture = false;
         captureImgCounter++;
-}
+} 

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -18,58 +18,11 @@ Gui::Gui(QMainWindow* win, Ui_GUI* ui_win) {
     //push button (to be renamed @Jake) connects to gallery capture
     QObject::connect(ui->pushButton, &QPushButton::released, this, &Gui::captureNextFrame);
 
-    //---- find or create gallery directory----
-    pathname = getenv("HOME");
-    pathname += + "/OpenFlexureGallery/"; 
-    
-    //if it doesn't exist
-    if ((dir = opendir(pathname.c_str())) == NULL){
-        //try to make the directory
-        if (mkdir(pathname.c_str(), S_IRWXU) == -1){
-            //if failed:
-            std::cerr << "Error :  " << std::strerror(errno) << std::endl;
-            std::cout << "Gallery directory not found/created";
-            //ADD. disable button if failed
-            pathname = ""; 
-            return;
-        }
-        else{//if gallery succesfully made
-            std::cout << "Gallery directory created at " + pathname << std::endl;
-        }
-    }else{//if gallery already exists
-        std::cout << "Gallery directory found at " + pathname << std::endl;
-        closedir(dir);
-    }
-
-    //(re)open already existing/newly created directory 
-    //to find if files with current name already exist
-    //to avoid overwriting the files
-    if ((dir = opendir(pathname.c_str())) != NULL) {
-        /* print all the files and directories within directory */
-        while ((ent = readdir(dir)) != NULL) {
-
-            //build filename to check if there
-            //build output name string
-            //captureFname = pathname + imgName + std::to_string(captureImgCounter) +".jpg";
-            
-            //get name of file
-            existingCaptureFname = ent->d_name;
-            if (existingCaptureFname.substr(0, imgName.length()) == imgName){
-                //get number of file
-                index = std::stoi(existingCaptureFname.substr(imgName.length(), 1));
-                //if index is higher than last highest found
-                if (index > lastHighestIndex){
-                    captureImgCounter = index + 1;
-                    lastHighestIndex = index;
-                }
-            } 
-        }
-    closedir(dir);
-    
-    //debug
-    std::cout << std::to_string(captureImgCounter) + " ALREADY FOUND" << std::endl;
-    }  
+    initialiseGallery();
 }
+
+
+
 void Gui::newFrame(frame newFrame) {
 
     //if capturing, capture before conversion to rgb
@@ -121,3 +74,58 @@ void Gui::captureFrame(frame capFrame){
         doCapture = false;
         captureImgCounter++;
 } 
+
+void Gui::initialiseGallery(){
+    //---- find or create gallery directory----
+    pathname = getenv("HOME");
+    pathname += + "/OpenFlexureGallery/"; 
+    
+    //if it doesn't exist
+    if ((dir = opendir(pathname.c_str())) == NULL){
+        //try to make the directory
+        if (mkdir(pathname.c_str(), S_IRWXU) == -1){
+            //if failed:
+            std::cerr << "Error :  " << std::strerror(errno) << std::endl;
+            std::cout << "Gallery directory not found/created";
+            //ADD. disable button if failed
+            pathname = ""; 
+            return;
+        }
+        else{//if gallery succesfully made
+            std::cout << "Gallery directory created at " + pathname << std::endl;
+        }
+    }else{//if gallery already exists
+        std::cout << "Gallery directory found at " + pathname << std::endl;
+        closedir(dir);
+    }
+
+    //(re)open already existing/newly created directory 
+    //to find if files with current name already exist
+    //to avoid overwriting the files
+    if ((dir = opendir(pathname.c_str())) != NULL) {
+        /* print all the files and directories within directory */
+        while ((ent = readdir(dir)) != NULL) {
+
+            //build filename to check if there
+            //build output name string
+            //captureFname = pathname + imgName + std::to_string(captureImgCounter) +".jpg";
+            
+            //get name of file
+            existingCaptureFname = ent->d_name;
+            if (existingCaptureFname.substr(0, imgName.length()) == imgName){
+                //get number of file
+                index = std::stoi(existingCaptureFname.substr(imgName.length(), 1));
+                //if index is higher than last highest found
+                if (index > lastHighestIndex){
+                    captureImgCounter = index + 1;
+                    lastHighestIndex = index;
+                }
+            } 
+        }
+    closedir(dir);
+    
+    //debug
+    std::cout << std::to_string(captureImgCounter) + " ALREADY FOUND" << std::endl;
+    }  
+
+}

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -13,14 +13,19 @@ Gui::Gui(QMainWindow* win, Ui_GUI* ui_win) {
     QObject::connect(ui->pushButton, &QPushButton::released, this, &Gui::captureNextFrame);
 
 
+    pathname = getenv("HOME");
+    pathname += + "/OpenFlexureGallery/"; 
     if (mkdir(pathname.c_str(), S_IRWXU) == -1){
     //if (mkdir("testMKDIR", S_IRWXU) == -1){
         std::cerr << "Error :  " << std::strerror(errno) << std::endl;
         std::cout << "Gallery directory not found/created";
+        //disable button if failed
     }
     else{
         std::cout << "Gallery directory found at " + pathname;
     }
+    //std::string home_dir = getenv("HOME");
+    //std::cout << home_dir <<std::endl;
 }
 void Gui::newFrame(frame newFrame) {
 

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1,26 +1,77 @@
 #include "gui.h"
 
+
+
 Gui::Gui(QMainWindow* win, Ui_GUI* ui_win) {
     widget = win;
     ui = ui_win;
     ui->setupUi(widget);
     //ui->logoImage->setPixmap(QPixmap(QString::fromUtf8("images/logo.png"))); add back in for future logo?
 
+    //make connections 
+    //push button (to be renamed @Jake) connects to gallery capture
+    QObject::connect(ui->pushButton, &QPushButton::released, this, &Gui::captureNextFrame);
+
+
+    if (mkdir(pathname.c_str(), S_IRWXU) == -1){
+    //if (mkdir("testMKDIR", S_IRWXU) == -1){
+        std::cerr << "Error :  " << std::strerror(errno) << std::endl;
+        std::cout << "Gallery directory not found/created";
+    }
+    else{
+        std::cout << "Gallery directory found at " + pathname;
+    }
 }
 void Gui::newFrame(frame newFrame) {
-    //maybe add some sort of protection here
-    cv::Mat img;
+
+
+    //if capturing, capture before conversion to rgb
+    if (doCapture){
+        //prob add some error handling
+        captureFrame(newFrame);
+    }
+
+    //maybe add some sort of protectiSon here
     img = newFrame.image; 
+    
+    //maybe try replacing img with newFrame.img to avoid unnecessary copying.
     //convert from default opencv bgr to QT rgb
     cv::cvtColor(img, img, cv::COLOR_BGR2RGB);
 
     QImage imgOut = QImage((uchar *) img.data, img.cols, img.rows, img.step,
                             QImage::Format_RGB888);
     ui->scopeVideoFeed->setPixmap(QPixmap::fromImage(imgOut));
-    ui->scopeVideoFeed->resize(ui->scopeVideoFeed->pixmap()->size());
-    
+    ui->scopeVideoFeed->resize(ui->scopeVideoFeed->pixmap()->size());   
 }
+    
+
 
 void Gui::SetVisible(bool visible) {
     widget->setVisible(visible);
+}
+
+//set to capture on next frame
+void Gui::captureNextFrame(){
+    doCapture = true;
+}
+
+//add some error handling
+void Gui::captureFrame(frame capFrame){
+        if (pathname == ""){
+            doCapture=false;
+            return;
+        }
+        //add ability to set custom string before number
+
+        //build output name string
+        captureFname = pathname + "testCapture_";
+        captureFname += std::to_string(captureImgCounter);
+        captureFname += ".jpg";
+
+
+        //save image
+        img = capFrame.image;
+        cv::imwrite(captureFname, img); //watch out for bgr vs rgb CHECK THIS
+        doCapture = false;
+        captureImgCounter++;
 }

--- a/src/gui.h
+++ b/src/gui.h
@@ -8,6 +8,8 @@
 #include <opencv2/imgproc.hpp>
 #include <opencv2/imgcodecs.hpp>
 #include "imageProcessor.h"
+#include <sys/types.h>
+#include <sys/stat.h>
 
 class Gui : public QWidget, public imageProcessor{ 
     Q_OBJECT
@@ -20,6 +22,15 @@ public:
 private:
     QMainWindow *widget;
     Ui_GUI *ui;
+    bool doCapture;
+    void captureNextFrame();
+    void captureFrame(frame);
+    cv::Mat img;
+
+    //std::string pathname = "~/OpenFlexureGallery"; //set this to "" later to require a definition somewhere 
+    std::string pathname = "testMKDIR/";
+    int captureImgCounter = 0;
+    std::string captureFname;
 };
 
 #endif // OPENFLEXURE_GUI_H

--- a/src/gui.h
+++ b/src/gui.h
@@ -38,7 +38,8 @@ private:
     int captureImgCounter = 0;
     std::string captureFname;
     int index;
-    int lastHighestIndex;
+    int lastHighestIndex = -1;
+    int indexLen = 1;
     std::string existingCaptureFname; 
 };
 #endif // OPENFLEXURE_GUI_H

--- a/src/gui.h
+++ b/src/gui.h
@@ -26,6 +26,7 @@ private:
     bool doCapture;
     void captureNextFrame();
     void captureFrame(frame);
+    void initialiseGallery();
     cv::Mat img;
 
 

--- a/src/gui.h
+++ b/src/gui.h
@@ -27,8 +27,9 @@ private:
     void captureFrame(frame);
     cv::Mat img;
 
-    //std::string pathname = "~/OpenFlexureGallery"; //set this to "" later to require a definition somewhere 
-    std::string pathname = "testMKDIR/";
+    
+    std::string pathname = "";
+    //std::string pathname = "testMKDIR/";
     int captureImgCounter = 0;
     std::string captureFname;
 };

--- a/src/gui.h
+++ b/src/gui.h
@@ -10,6 +10,7 @@
 #include "imageProcessor.h"
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <dirent.h>
 
 class Gui : public QWidget, public imageProcessor{ 
     Q_OBJECT
@@ -26,10 +27,11 @@ private:
     void captureNextFrame();
     void captureFrame(frame);
     cv::Mat img;
+    DIR *dir;
 
     
     std::string pathname = "";
-    //std::string pathname = "testMKDIR/";
+    std::string imgName = "capture";
     int captureImgCounter = 0;
     std::string captureFname;
 };

--- a/src/gui.h
+++ b/src/gui.h
@@ -27,13 +27,17 @@ private:
     void captureNextFrame();
     void captureFrame(frame);
     cv::Mat img;
-    DIR *dir;
 
-    
+
+    //Gallery attributes
+    DIR *dir;
+    struct dirent *ent;
     std::string pathname = "";
     std::string imgName = "capture";
     int captureImgCounter = 0;
     std::string captureFname;
+    int index;
+    int lastHighestIndex;
+    std::string existingCaptureFname; 
 };
-
 #endif // OPENFLEXURE_GUI_H

--- a/src/imageProcessor.h
+++ b/src/imageProcessor.h
@@ -19,6 +19,10 @@ public:
         std::string note;
         //edge detection threshold metadata
         float edgeThreshold;
+
+        //ideas:
+        //low res version for gallery view?
+        //original un-enhanced version. 
     };
 
     virtual void newFrame(frame newFrame) = 0; 


### PR DESCRIPTION
Ties gui pushbutton to capture a frame from the feed in a gallery directory. Upon startup, the gallery directory is created if it doesn't already exist and the highest existing indexed capture is found. These have a naming convention of "captureX.jpg" where X is an integer of any length. New captures in a new instance of the executeable do not overwrite previous cp